### PR TITLE
Fix card type interface

### DIFF
--- a/backend/src/models/Board.ts
+++ b/backend/src/models/Board.ts
@@ -2,7 +2,7 @@
 import mongoose, { Schema, Document } from "mongoose";
 
 // Card interface
-export interface ICard extends Document {
+export interface ICard {
   text: string;
   author: string;
   votes: number;
@@ -10,7 +10,7 @@ export interface ICard extends Document {
 }
 
 // Column interface
-export interface IColumn extends Document {
+export interface IColumn {
   title: string;
   cards: ICard[];
 }


### PR DESCRIPTION
## Summary
- define ICard and IColumn without extending `Document` to allow pushing plain objects

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684aacc549d0832da3a9d9df6b525551